### PR TITLE
Fix havok material version check.

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -1909,8 +1909,8 @@
     <niobject name="bhkTransformShape" abstract="0" inherit="bhkShape">
         Transforms a shape.
         <add name="Shape" type="Ref" template="bhkShape">The shape that this object transforms.</add>
-        <add name="Material" type="HavokMaterial" vercond="((Version != 20.2.0.7) &amp;&amp; (User Version != 12) &amp;&amp; (User Version 2 != 83))">The shape&#039;s material.</add>
-        <add name="Skyrim Material" type="SkyrimHavokMaterial" ver1="20.2.0.7" userver="12" userver2="83">The shape&#039;s material.</add>
+        <add name="Material" type="HavokMaterial" vercond="User Version &lt; 12">The shape&#039;s material.</add>
+        <add name="Skyrim Material" type="SkyrimHavokMaterial" vercond="User Version >= 12">The shape&#039;s material.</add>
         <add name="Unknown Float 1" type="float">Unknown.</add>
         <add name="Unknown 8 Bytes" type="byte" arr1="8">Unknown.</add>
         <add name="Transform" type="Matrix44">A transform matrix.</add>
@@ -1918,8 +1918,8 @@
 
     <niobject name="bhkSphereRepShape" abstract="1" inherit="bhkShape">
         A havok shape, perhaps with a bounding sphere for quick rejection in addition to more detailed shape data?
-        <add name="Material" type="HavokMaterial" vercond="((Version != 20.2.0.7) &amp;&amp; (User Version != 12) &amp;&amp; (User Version 2 != 83))">The shape&#039;s material.</add>
-        <add name="Skyrim Material" type="SkyrimHavokMaterial" ver1="20.2.0.7" userver="12" userver2="83">The shape&#039;s material.</add>
+        <add name="Material" type="HavokMaterial" vercond="User Version &lt; 12">The shape&#039;s material.</add>
+        <add name="Skyrim Material" type="SkyrimHavokMaterial" vercond="User Version >= 12">The shape&#039;s material.</add>
         <add name="Radius" type="float">The radius of the sphere that encloses the shape.</add>
     </niobject>
 
@@ -1979,8 +1979,8 @@
     <niobject name="bhkMoppBvTreeShape" abstract="0" inherit="bhkBvTreeShape">
         Memory optimized partial polytope bounding volume tree shape (not an entity).
         <add name="Shape" type="Ref" template="bhkShape">The shape.</add>
-        <add name="Material" type="HavokMaterial" vercond="((Version != 20.2.0.7) &amp;&amp; (User Version != 12) &amp;&amp; (User Version 2 != 83))">The shape&#039;s material.</add>
-        <add name="Skyrim Material" type="SkyrimHavokMaterial" ver1="20.2.0.7" userver="12" userver2="83">The shape&#039;s material.</add>
+        <add name="Material" type="HavokMaterial" vercond="User Version &lt; 12">The shape&#039;s material.</add>
+        <add name="Skyrim Material" type="SkyrimHavokMaterial" vercond="User Version >= 12">The shape&#039;s material.</add>
         <add name="Unknown 8 Bytes" type="byte" arr1="8">Unknown bytes.</add>
         <add name="Unknown Float" type="float" default="1.0">Unknown float, might be scale.</add>
         <add name="MOPP Data Size" type="uint" calculated="1">Number of bytes for MOPP data.</add>
@@ -2006,8 +2006,8 @@
         walking noise, so only use it for non-walkable objects.
         <add name="Num Sub Shapes" type="uint">The number of sub shapes referenced.</add>
         <add name="Sub Shapes" type="Ref" template="bhkShape" arr1="Num Sub Shapes">List of shapes.</add>
-        <add name="Material" type="HavokMaterial" vercond="((Version != 20.2.0.7) &amp;&amp; (User Version != 12) &amp;&amp; (User Version 2 != 83))">The shape&#039;s material.</add>
-        <add name="Skyrim Material" type="SkyrimHavokMaterial" ver1="20.2.0.7" userver="12" userver2="83">The shape&#039;s material.</add>
+        <add name="Material" type="HavokMaterial" vercond="User Version &lt; 12">The shape&#039;s material.</add>
+        <add name="Skyrim Material" type="SkyrimHavokMaterial" vercond="User Version >= 12">The shape&#039;s material.</add>
         <add name="Unknown Floats" type="float" arr1="6">Unknown. Set to (0.0,0.0,-0.0,0.0,0.0,-0.0), where -0.0 is 0x80000000 in hex.</add>
         <add name="Num Unknown Ints" type="uint">Count.</add>
         <add name="Unknown Ints" type="uint" arr1="Num Unknown Ints">Unknown.</add>
@@ -2048,8 +2048,8 @@
 
     <niobject name="bhkNiTriStripsShape" abstract="0" inherit="bhkShapeCollection">
         A shape constructed from a bunch of strips.
-        <add name="Material" type="HavokMaterial" vercond="((Version != 20.2.0.7) &amp;&amp; (User Version != 12) &amp;&amp; (User Version 2 != 83))">The shape&#039;s material.</add>
-        <add name="Skyrim Material" type="SkyrimHavokMaterial" ver1="20.2.0.7" userver="12" userver2="83">The shape&#039;s material.</add>
+        <add name="Material" type="HavokMaterial" vercond="User Version &lt; 12">The shape&#039;s material.</add>
+        <add name="Skyrim Material" type="SkyrimHavokMaterial" vercond="User Version >= 12">The shape&#039;s material.</add>
         <add name="Unknown Float 1" type="float" default="0.1">Unknown.</add>
         <add name="Unknown Int 1" type="uint" default="0x004ABE60">Unknown.</add>
         <add name="Unknown Ints 1" type="uint" arr1="4">Unknown.</add>
@@ -4861,8 +4861,8 @@
         walking noise, so only use it for non-walkable objects.
         <add name="Num Sub Shapes" type="uint">The number of sub shapes referenced.</add>
         <add name="Sub Shapes" type="Ref" template="bhkConvexShape" arr1="Num Sub Shapes">List of shapes.</add>
-        <add name="Material" type="HavokMaterial" vercond="((Version != 20.2.0.7) &amp;&amp; (User Version != 12) &amp;&amp; (User Version 2 != 83))">The shape&#039;s material.</add>
-        <add name="Skyrim Material" type="SkyrimHavokMaterial" ver1="20.2.0.7" userver="12" userver2="83">The shape&#039;s material.</add>
+        <add name="Material" type="HavokMaterial" vercond="User Version &lt; 12">The shape&#039;s material.</add>
+        <add name="Skyrim Material" type="SkyrimHavokMaterial" vercond="User Version >= 12">The shape&#039;s material.</add>
         <add name="Unknown Floats" type="float" arr1="6" default="0.0 0.0 -0.0 0.0 0.0 -0.0">Unknown. Set to (0.0,0.0,-0.0,0.0,0.0,-0.0), where -0.0 is 0x80000000 in hex.</add>
         <add name="Unknown Byte 1" type="byte" >Unknown Flag</add>
         <add name="Unknown Float 1" type="float">Unknown Flag</add>


### PR DESCRIPTION
@ttl269 @neomonkeus Not tested yet, but this looks like the simplest solution (explanation: as bhk blocks only occur in bethesda nifs anyway, the user version check should be sufficient).

Ok to merge (pending my own testing still)?
